### PR TITLE
Gsheet

### DIFF
--- a/GoogleSheet/src/main/java/us/dontcareabout/googleSheet/DateInterval.java
+++ b/GoogleSheet/src/main/java/us/dontcareabout/googleSheet/DateInterval.java
@@ -1,7 +1,5 @@
 package us.dontcareabout.googleSheet;
 
-import us.dontcareabout.googleSheet.Exceptions.DateIntervalException;
-
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
@@ -9,11 +7,16 @@ public class DateInterval {
 	private Date start;
 	private Date end;
 
-	public DateInterval(Date start, Date end) {
-		if (start.after(end)) {
-			throw new DateIntervalException("Start date is not earlier than end date");
-		}
+	public DateInterval(Date date1, Date date2) {
+		this.start = date1.before(date2) ? date1 : date2;
+		this.end = date1.after(date2) ? date1 : date2;
+	}
+
+	public void setStart(Date start) {
 		this.start = start;
+	}
+
+	public void setEnd(Date end) {
 		this.end = end;
 	}
 
@@ -26,10 +29,10 @@ public class DateInterval {
 	}
 
 	public boolean containInterval(DateInterval innerInterval) {
-		if (start.getTime() > innerInterval.start.getTime()) {
+		if (start.after(innerInterval.start)) {
 			return false;
 		}
-		if (end.getTime() < innerInterval.end.getTime()) {
+		if (end.before(innerInterval.end)) {
 			return false;
 		}
 		return true;

--- a/GoogleSheet/src/main/java/us/dontcareabout/googleSheet/DateInterval.java
+++ b/GoogleSheet/src/main/java/us/dontcareabout/googleSheet/DateInterval.java
@@ -1,6 +1,7 @@
 package us.dontcareabout.googleSheet;
 
 import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.Date;
 
 public class DateInterval {
@@ -36,6 +37,20 @@ public class DateInterval {
 			return false;
 		}
 		return true;
+	}
+
+	/**
+	 * 移動日期
+	 *
+	 * @param date 移動前的日期
+	 * @param days 移動天數
+	 * @return Date
+	 */
+	public static Date shiftDate(Date date, int days) {
+		Calendar c = Calendar.getInstance();
+		c.setTime(date);
+		c.add(Calendar.DATE, days);
+		return c.getTime();
 	}
 
 	@Override

--- a/GoogleSheet/src/main/java/us/dontcareabout/googleSheet/Exhibition.java
+++ b/GoogleSheet/src/main/java/us/dontcareabout/googleSheet/Exhibition.java
@@ -56,8 +56,8 @@ public class Exhibition {
 			DateInterval newInterval = null;
 			for (DateInterval d : openIntervals.get(sr)) {
 				if (d.containInterval(changeInterval)) {
-					newInterval = new DateInterval(changeInterval.getEnd(), d.getEnd());
-					d.setEnd(changeInterval.getStart());
+					newInterval = new DateInterval(DateInterval.shiftDate(changeInterval.getEnd(), 1), d.getEnd());
+					d.setEnd(DateInterval.shiftDate(changeInterval.getStart(), -1));
 					break;
 				}
 			}
@@ -81,6 +81,6 @@ public class Exhibition {
 
 	@Override
 	public String toString() {
-		return String.format("Exhibition:\nName: %s\nDate: %s\nLocation: %s\nOpen Date:\n%s\n", name, getDisplayDate(), getRooms(), getOpenIntervals());
+		return String.format("Exhibition:\nName: %s\nDate: %s\nLocation: %s\nOpen Date:\n%s\nClose count: %s\n", name, getDisplayDate(), getRooms(), getOpenIntervals(), getCloseCount());
 	}
 }


### PR DESCRIPTION
update

------------

關於 #30 的最後一個 [comment](https://github.com/MontyPan/T-Chou/pull/30#pullrequestreview-275832950) 有一點疑惑

> 關於第二點，我是真心不覺得現在的 `ShowRoom` 的作法（或著說 `Main.getRoomInfo()`）是個好主意，或著反過來說，我拿到 `ShowRoom` 可以幹麼？如果遇到的是 S101 就是一個展，換展也是整個展廳關掉，那是不是更麻煩了些（這裡可以接「哪一種 case 佔多數」的問題 + 80/20 法則，不過如果可以有 total solution 幹麼只生 partial solution？）。當然這是不是套個 enum 就能解決.... 應該不行 XD，但至少能先踏出比較乾淨的一步。

我的想法是，這個 `ShowRoom` 是可以存放在這個展廳展出的所有展覽資訊，比較容易畫成 #28 的[展場圖](https://github.com/MontyPan/T-Chou/pull/28#issuecomment-514772234)。

一開始是想說開是要把 `Exhibition` 放在 `ShowRoom` 裡面，或是 `ShowRoom` 放在 `Exibition` 裡面，但是不管是哪一種設計，要把另一個資料抽出來感覺都有點麻煩，所以就弄出來 `getExhibitionInfo()` 跟 `getRoomInfo()` 這兩個 method，分別處理兩個需求。

另外，由於展廳可能會被分成一半，那麼，在設計展廳的時候，就以半個展廳為最小單位。例如：使用 S301 的展覽，就當成使用 S301A, S301B 兩個展廳，這樣就只要處理多個展廳的問題，而不用擔心半個展廳的問題。

還有原本展廳的名稱就很有系統，你提到的父子展廳，我不太了解它的功能。


------------------------

> 甚至是在 `addCloseIntervals()` 的時候才視情況把一個 `Room` 拆成兩個 `Room`。（預防性補刀：開展閉展應該都會一起，所以隨便抓個哪個 `Room` 來得到原本的 `displayDate` 就行）

展覽的 `displayDate` 應該會是固定的吧，那一開始就設計一個 field 來存這筆資料不是比較簡單嗎？為什麼還要把一段時間分成好幾部分，之後再把它拼回去？